### PR TITLE
Migrate from xblock-utils package to xblock.utils

### DIFF
--- a/imagemodal/views.py
+++ b/imagemodal/views.py
@@ -1,8 +1,12 @@
 """
 Handle view logic for the XBlock
 """
-from xblockutils.resources import ResourceLoader
-from xblockutils.studio_editable import StudioEditableXBlockMixin
+try:
+    from xblock.utils.resources import ResourceLoader
+    from xblock.utils.studio_editable import StudioEditableXBlockMixin
+except ModuleNotFoundError:  # For backward compatibility with releases older than Quince.
+    from xblockutils.resources import ResourceLoader
+    from xblockutils.studio_editable import StudioEditableXBlockMixin
 
 from .mixins.fragment import XBlockFragmentBuilderMixin
 

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -4,4 +4,3 @@
 Django
 six
 XBlock
-xblock-utils

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,81 +8,44 @@ appdirs==1.4.4
     # via fs
 asgiref==3.7.2
     # via django
-boto3==1.28.68
-    # via fs-s3fs
-botocore==1.31.68
-    # via
-    #   boto3
-    #   s3transfer
 django==3.2.22
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.in
-    #   openedx-django-pyfs
 fs==2.4.16
-    # via
-    #   fs-s3fs
-    #   openedx-django-pyfs
-    #   xblock
-fs-s3fs==1.1.1
-    # via openedx-django-pyfs
-jmespath==1.0.1
-    # via
-    #   boto3
-    #   botocore
-lazy==1.6
     # via xblock
 lxml==4.9.3
     # via xblock
 mako==1.2.4
-    # via
-    #   xblock
-    #   xblock-utils
+    # via xblock
 markupsafe==2.1.3
     # via
     #   mako
     #   xblock
-openedx-django-pyfs==3.4.0
-    # via xblock
 python-dateutil==2.8.2
-    # via
-    #   botocore
-    #   xblock
+    # via xblock
 pytz==2023.3.post1
     # via
     #   django
     #   xblock
 pyyaml==6.0.1
     # via xblock
-s3transfer==0.7.0
-    # via boto3
 simplejson==3.19.2
-    # via
-    #   xblock
-    #   xblock-utils
+    # via xblock
 six==1.16.0
     # via
     #   -r requirements/base.in
     #   fs
-    #   fs-s3fs
     #   python-dateutil
 sqlparse==0.4.4
     # via django
 typing-extensions==4.8.0
     # via asgiref
-urllib3==1.26.18
-    # via botocore
 web-fragments==2.1.0
-    # via
-    #   xblock
-    #   xblock-utils
+    # via xblock
 webob==1.8.7
     # via xblock
-xblock[django]==1.8.1
-    # via
-    #   -r requirements/base.in
-    #   xblock-utils
-xblock-utils==4.0.0
+xblock==1.8.1
     # via -r requirements/base.in
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -18,7 +18,7 @@ distlib==0.3.7
     #   virtualenv
 docopt==0.6.2
     # via coveralls
-filelock==3.12.4
+filelock==3.13.0
     # via
     #   -r requirements/tox.txt
     #   tox
@@ -57,7 +57,7 @@ tox==3.28.0
     #   -r requirements/tox.txt
 urllib3==2.0.7
     # via requests
-virtualenv==20.24.5
+virtualenv==20.24.6
     # via
     #   -r requirements/tox.txt
     #   tox

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-wheel==0.41.2
+wheel==0.41.3
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -21,7 +21,7 @@ tomli==2.0.1
     #   build
     #   pip-tools
     #   pyproject-hooks
-wheel==0.41.2
+wheel==0.41.3
     # via pip-tools
 zipp==3.17.0
     # via importlib-metadata

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -17,15 +17,6 @@ astroid==3.0.1
     #   -r requirements/test.txt
     #   pylint
     #   pylint-celery
-boto3==1.28.68
-    # via
-    #   -r requirements/base.txt
-    #   fs-s3fs
-botocore==1.31.68
-    # via
-    #   -r requirements/base.txt
-    #   boto3
-    #   s3transfer
 click==8.1.7
     # via
     #   -r requirements/test.txt
@@ -50,21 +41,14 @@ django==3.2.22
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.txt
-    #   openedx-django-pyfs
-edx-lint==5.3.4
+edx-lint==5.3.6
     # via -r requirements/test.txt
 edx-opaque-keys==2.5.1
     # via -r requirements/test.txt
 fs==2.4.16
     # via
     #   -r requirements/base.txt
-    #   fs-s3fs
-    #   openedx-django-pyfs
     #   xblock
-fs-s3fs==1.1.1
-    # via
-    #   -r requirements/base.txt
-    #   openedx-django-pyfs
 isort==5.12.0
     # via
     #   -r requirements/test.txt
@@ -73,15 +57,6 @@ jinja2==3.1.2
     # via
     #   -r requirements/test.txt
     #   code-annotations
-jmespath==1.0.1
-    # via
-    #   -r requirements/base.txt
-    #   boto3
-    #   botocore
-lazy==1.6
-    # via
-    #   -r requirements/base.txt
-    #   xblock
 lxml==4.9.3
     # via
     #   -r requirements/base.txt
@@ -90,7 +65,6 @@ mako==1.2.4
     # via
     #   -r requirements/base.txt
     #   xblock
-    #   xblock-utils
 markupsafe==2.1.3
     # via
     #   -r requirements/base.txt
@@ -104,10 +78,6 @@ mccabe==0.7.0
     #   pylint
 mock==5.1.0
     # via -r requirements/test.txt
-openedx-django-pyfs==3.4.0
-    # via
-    #   -r requirements/base.txt
-    #   xblock
 pbr==5.11.1
     # via
     #   -r requirements/test.txt
@@ -130,7 +100,7 @@ pylint-celery==0.3
     # via
     #   -r requirements/test.txt
     #   edx-lint
-pylint-django==2.5.4
+pylint-django==2.5.5
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -146,7 +116,6 @@ pymongo==3.13.0
 python-dateutil==2.8.2
     # via
     #   -r requirements/base.txt
-    #   botocore
     #   xblock
 python-slugify==8.0.1
     # via
@@ -163,22 +132,16 @@ pyyaml==6.0.1
     #   -r requirements/test.txt
     #   code-annotations
     #   xblock
-s3transfer==0.7.0
-    # via
-    #   -r requirements/base.txt
-    #   boto3
 simplejson==3.19.2
     # via
     #   -r requirements/base.txt
     #   xblock
-    #   xblock-utils
 six==1.16.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
     #   edx-lint
     #   fs
-    #   fs-s3fs
     #   python-dateutil
 sqlparse==0.4.4
     # via
@@ -209,25 +172,15 @@ typing-extensions==4.8.0
     #   astroid
     #   edx-opaque-keys
     #   pylint
-urllib3==1.26.18
-    # via
-    #   -r requirements/base.txt
-    #   botocore
 web-fragments==2.1.0
     # via
     #   -r requirements/base.txt
     #   xblock
-    #   xblock-utils
 webob==1.8.7
     # via
     #   -r requirements/base.txt
     #   xblock
-xblock[django]==1.8.1
-    # via
-    #   -r requirements/base.txt
-    #   xblock
-    #   xblock-utils
-xblock-utils==4.0.0
+xblock==1.8.1
     # via -r requirements/base.txt
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -21,7 +21,7 @@ coverage==7.3.2
     # via -r requirements/test.in
 dill==0.3.7
     # via pylint
-edx-lint==5.3.4
+edx-lint==5.3.6
     # via -r requirements/test.in
 edx-opaque-keys==2.5.1
     # via -r requirements/test.in
@@ -47,7 +47,7 @@ pylint==3.0.2
     #   pylint-plugin-utils
 pylint-celery==0.3
     # via edx-lint
-pylint-django==2.5.4
+pylint-django==2.5.5
     # via edx-lint
 pylint-plugin-utils==0.8.2
     # via

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -6,7 +6,7 @@
 #
 distlib==0.3.7
     # via virtualenv
-filelock==3.12.4
+filelock==3.13.0
     # via
     #   tox
     #   virtualenv
@@ -26,5 +26,5 @@ tox==3.28.0
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/tox.in
-virtualenv==20.24.5
+virtualenv==20.24.6
     # via tox

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from os import path
 
 from setuptools import setup
 
-version = '3.1.0'
+version = '3.2.0'
 description = __doc__.strip().split('\n')[0]
 this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, 'README.rst')) as file_in:


### PR DESCRIPTION
ticket: https://github.com/openedx/xblock-image-modal/issues/131

# Overview
What do we need to know about this change?

# Screenshot of xblock after PR implementation:
![image](https://github.com/openedx/xblock-image-modal/assets/25842457/1b74d7d6-f44d-4f8a-bcdf-259b604d9674)


# Test Instructions
- Checkout the branch
- Update settings?
- Anything else?

# TODO
- [ ] Compile static assets
- [ ] Lint all files
- [x] Pass all tests
- [ ] Bump the version number in `setup.py`
- [x] Attach screenshots?
- [x] Code Reviewer 1:
- [x] Code Reviewer 2:
- [ ] Submit PR against `edx-platform` to bump the version
- [ ] Upload to PyPi
