### PR TITLE
fix: include constraints in test.txt

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,7 +8,7 @@ appdirs==1.4.4
     # via fs
 asgiref==3.7.2
     # via django
-django==3.2.22
+django==3.2.23
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.in
@@ -16,7 +16,7 @@ fs==2.4.16
     # via xblock
 lxml==4.9.3
     # via xblock
-mako==1.2.4
+mako==1.3.0
     # via xblock
 markupsafe==2.1.3
     # via

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,10 +4,22 @@
 #
 #    make upgrade
 #
+cachetools==5.3.2
+    # via
+    #   -r requirements/tox.txt
+    #   tox
 certifi==2023.7.22
     # via requests
-charset-normalizer==3.3.1
+chardet==5.2.0
+    # via
+    #   -r requirements/tox.txt
+    #   tox
+charset-normalizer==3.3.2
     # via requests
+colorama==0.4.6
+    # via
+    #   -r requirements/tox.txt
+    #   tox
 coverage==6.5.0
     # via coveralls
 coveralls==3.3.1
@@ -18,7 +30,7 @@ distlib==0.3.7
     #   virtualenv
 docopt==0.6.2
     # via coveralls
-filelock==3.13.0
+filelock==3.13.1
     # via
     #   -r requirements/tox.txt
     #   tox
@@ -28,34 +40,32 @@ idna==3.4
 packaging==23.2
     # via
     #   -r requirements/tox.txt
+    #   pyproject-api
     #   tox
 platformdirs==3.11.0
     # via
+    #   -c requirements/common_constraints.txt
     #   -r requirements/tox.txt
+    #   tox
     #   virtualenv
 pluggy==1.3.0
     # via
     #   -r requirements/tox.txt
     #   tox
-py==1.11.0
+pyproject-api==1.6.1
     # via
     #   -r requirements/tox.txt
     #   tox
 requests==2.31.0
     # via coveralls
-six==1.16.0
-    # via
-    #   -r requirements/tox.txt
-    #   tox
 tomli==2.0.1
     # via
     #   -r requirements/tox.txt
+    #   pyproject-api
     #   tox
-tox==3.28.0
-    # via
-    #   -c requirements/common_constraints.txt
-    #   -r requirements/tox.txt
-urllib3==2.0.7
+tox==4.11.3
+    # via -r requirements/tox.txt
+urllib3==2.1.0
     # via requests
 virtualenv==20.24.6
     # via

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -22,6 +22,7 @@ elasticsearch<7.14.0
 # django-simple-history>3.0.0 adds indexing and causes a lot of migrations to be affected
 django-simple-history==3.0.0
 
-# tox>4.0.0 isn't yet compatible with many tox plugins, causing CI failures in almost all repos.
-# Details can be found in this discussion: https://github.com/tox-dev/tox/discussions/1810
-tox<4.0.0
+# virtualenv latest version requires platformdirs<4.0 which conflicts with tox>4.0 version
+# This constraint can be removed once the issue 
+# https://github.com/pypa/virtualenv/issues/2666 gets resolved 
+platformdirs<4.0

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -37,7 +37,7 @@ dill==0.3.7
     # via
     #   -r requirements/test.txt
     #   pylint
-django==3.2.22
+django==3.2.23
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.txt
@@ -61,7 +61,7 @@ lxml==4.9.3
     # via
     #   -r requirements/base.txt
     #   xblock
-mako==1.2.4
+mako==1.3.0
     # via
     #   -r requirements/base.txt
     #   xblock
@@ -78,12 +78,13 @@ mccabe==0.7.0
     #   pylint
 mock==5.1.0
     # via -r requirements/test.txt
-pbr==5.11.1
+pbr==6.0.0
     # via
     #   -r requirements/test.txt
     #   stevedore
 platformdirs==3.11.0
     # via
+    #   -c requirements/common_constraints.txt
     #   -r requirements/test.txt
     #   pylint
 pycodestyle==2.11.1
@@ -160,7 +161,7 @@ tomli==2.0.1
     # via
     #   -r requirements/test.txt
     #   pylint
-tomlkit==0.12.1
+tomlkit==0.12.3
     # via
     #   -r requirements/test.txt
     #   pylint

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -1,4 +1,5 @@
 # Requirements for test runs
+-c constraints.txt
 
 coverage
 edx-lint

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -35,10 +35,12 @@ mccabe==0.7.0
     # via pylint
 mock==5.1.0
     # via -r requirements/test.in
-pbr==5.11.1
+pbr==6.0.0
     # via stevedore
 platformdirs==3.11.0
-    # via pylint
+    # via
+    #   -c requirements/common_constraints.txt
+    #   pylint
 pylint==3.0.2
     # via
     #   edx-lint
@@ -69,7 +71,7 @@ text-unidecode==1.3
     # via python-slugify
 tomli==2.0.1
     # via pylint
-tomlkit==0.12.1
+tomlkit==0.12.3
     # via pylint
 typing-extensions==4.8.0
     # via

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -4,27 +4,36 @@
 #
 #    make upgrade
 #
+cachetools==5.3.2
+    # via tox
+chardet==5.2.0
+    # via tox
+colorama==0.4.6
+    # via tox
 distlib==0.3.7
     # via virtualenv
-filelock==3.13.0
+filelock==3.13.1
     # via
     #   tox
     #   virtualenv
 packaging==23.2
-    # via tox
+    # via
+    #   pyproject-api
+    #   tox
 platformdirs==3.11.0
-    # via virtualenv
-pluggy==1.3.0
-    # via tox
-py==1.11.0
-    # via tox
-six==1.16.0
-    # via tox
-tomli==2.0.1
-    # via tox
-tox==3.28.0
     # via
     #   -c requirements/common_constraints.txt
-    #   -r requirements/tox.in
+    #   tox
+    #   virtualenv
+pluggy==1.3.0
+    # via tox
+pyproject-api==1.6.1
+    # via tox
+tomli==2.0.1
+    # via
+    #   pyproject-api
+    #   tox
+tox==4.11.3
+    # via -r requirements/tox.in
 virtualenv==20.24.6
     # via tox


### PR DESCRIPTION
## Description
- Include `constraints.txt` in `test.txt` requirements to fix the requirements upgrade job. 
- Including constraints helps in getting the latest global constraint of `platformdirs` and resolve the [failing](https://github.com/openedx/xblock-image-modal/actions/runs/6885235445) requirements upgrade job. 