### PR TITLE
fix: remove deprecated xblock.fragment import

### DIFF
--- a/imagemodal/mixins/fragment.py
+++ b/imagemodal/mixins/fragment.py
@@ -8,7 +8,7 @@ from django.template.context import Context
 from xblock.core import XBlock
 try:
     from web_fragments.fragment import Fragment
-except:
+except ImportError:
     # for backwards compatibility with quince and prior releases
     from xblock.fragment import Fragment
 

--- a/imagemodal/mixins/fragment.py
+++ b/imagemodal/mixins/fragment.py
@@ -6,7 +6,11 @@ split into its own library.
 """
 from django.template.context import Context
 from xblock.core import XBlock
-from xblock.fragment import Fragment
+try:
+    from web_fragments.fragment import Fragment
+except:
+    # for backwards compatibility with quince and prior releases
+    from xblock.fragment import Fragment
 
 
 class XBlockFragmentBuilderMixin:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from os import path
 
 from setuptools import setup
 
-version = '3.2.0'
+version = '3.2.1'
 description = __doc__.strip().split('\n')[0]
 this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, 'README.rst')) as file_in:


### PR DESCRIPTION
## Description
This replace `xblock.fragment` with `web_fragments.fragment`. `xblock.fragment` was [removed as of 2024-02-26](https://docs.openedx.org/projects/xblock/en/latest/changelog.html#id2). If this xblock is used in a course, the entire course will fail to load.