### PR TITLE
Feat: Add django52 Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         python-version:
         - '3.11'
         - '3.12'
-        toxenv: [django42, quality, csslint, eslint]
+        toxenv: [django42, django52, quality, csslint, eslint]
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from os import path
 
 from setuptools import setup
 
-version = '4.0.0'
+version = '4.1.0'
 description = __doc__.strip().split('\n')[0]
 this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, 'README.rst')) as file_in:
@@ -125,6 +125,7 @@ setup(
         'Topic :: Internet :: WWW/HTTP',
         'Framework :: Django',
         'Framework :: Django :: 4.2',
+        'Framework :: Django :: 5.2',
     ],
     test_suite='imagemodal.tests',
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,10 @@
 [tox]
-envlist = csslint,eslint,py{311,312}-django{42},quality
+envlist = csslint,eslint,py{311,312}-django{42,52},quality
 
 [testenv]
 deps =
     django42: Django>=4.2,<4.3
+    django52: Django>=5.2,<5.3
     -rrequirements/test.txt
 commands =
     coverage run manage.py test


### PR DESCRIPTION
Resolve [Add Django 5.2 support to xblock-image-modal](https://github.com/openedx/xblock-image-modal/issues/228)

## Add Django 5.2 Support
This PR updates the codebase to be compatible with Django 5.2 while maintaining compatibility with Django 4.2.

### Changes Made:
- Update ci and tox files
- Ran django-upgrade to apply necessary syntax updates for Django 5.2.
- Run tests using tox command and resolved the warning
- Ensured all modifications remain backward-compatible with Django 4.2.

### django-upgrade usage:
`git ls-files -z -- '*.py' | xargs -0r django-upgrade --target-version 5.2`
