### PR TITLE
Mark repository as deprecated and point to xblocks-extra

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,13 @@
+![Status](https://img.shields.io/badge/status-deprecated-red)
+
+## ⚠️ This Repository is Deprecated
+This repository is no longer maintained.
+
+The Image Modal XBlock has been moved to:
+👉 https://github.com/openedx/xblocks-extra
+
+Please use the new repository for all future work.
+
 Image Modal XBlock
 ==================
 

--- a/README.rst
+++ b/README.rst
@@ -1,16 +1,21 @@
 .. image:: https://img.shields.io/badge/status-deprecated-red
    :alt: Status
 
-Deprecation
-===========
+⚠️ Repository Migration Notice ⚠️
+***********************************
 
-**This repository is no longer maintained.**
+.. warning::
 
-The Image Modal XBlock has been moved to `xblocks-extra <https://github.com/openedx/xblocks-extra>`_.
+   This ``xblock-image-modal`` repository is being archived. The  XBlock
+   is moving to the `xblocks-extra <https://github.com/openedx/xblocks-extra>`_ repository,
+   which consolidates optional add-on XBlocks for the Open edX platform.
 
-Please use the new repository for all future work.
+   **Archival:** This repository will become read-only once the migration is complete.
+   No further updates or changes will be accepted here.
 
-----
+   Please use `xblocks-extra <https://github.com/openedx/xblocks-extra>`_ for all future work.
+   If you have any questions or concerns, please open an issue on the
+   `xblocks-extra issue tracker <https://github.com/openedx/xblocks-extra/issues>`_.
 
 Image Modal XBlock
 ==================

--- a/README.rst
+++ b/README.rst
@@ -1,12 +1,16 @@
-![Status](https://img.shields.io/badge/status-deprecated-red)
+.. image:: https://img.shields.io/badge/status-deprecated-red
+   :alt: Status
 
-## ⚠️ This Repository is Deprecated
-This repository is no longer maintained.
+Deprecation
+===========
 
-The Image Modal XBlock has been moved to:
-👉 https://github.com/openedx/xblocks-extra
+**This repository is no longer maintained.**
+
+The Image Modal XBlock has been moved to `xblocks-extra <https://github.com/openedx/xblocks-extra>`_.
 
 Please use the new repository for all future work.
+
+----
 
 Image Modal XBlock
 ==================


### PR DESCRIPTION
This repo is no longer maintained here and has been moved to the xblocks-extra repository. A badge and message have been added to guide users to the new location for any future development or usage.

Readme preview after this PR: https://github.com/farhan/xblock-image-modal/blob/852b07ae134eeda3783ef987011578ed8b45de83/README.rst

Relevant PR: https://github.com/openedx/xblocks-extra/pull/12